### PR TITLE
Docreader/FaceAPI. Fixes

### DIFF
--- a/docreader/terraform/modules/app/provider.tf
+++ b/docreader/terraform/modules/app/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = local.region
+}

--- a/faceapi/README.md
+++ b/faceapi/README.md
@@ -52,7 +52,10 @@ Terraform is an Infrastructure as Code (IaC) software tool. With Terraform, you 
 >   - The Packer image also should have `faceapi_engine` set to `gpu`.
 
 > [!NOTE]
-> Default AWS quota quota name doesn't allow to run G spot instances, please ensure you've approved request quota limit (L-3819A6DF) before you launch terraform or set instance type to on-demand by following.
+> Default AWS quota `All G and VT Spot Instance Requests` doesn't allow to run G spot instances, please ensure you've approved request quota limit (`arn:aws:servicequotas:AWS_REGION:AWS_ACCOUNT_ID:ec2/L-3819A6DF`) before you launch terraform or set instance type to on-demand by following.
+
+> [!NOTE]
+> If you don't want to use `Spot` instances, please, set `asg_on_demand_base_capacity = 1 and  asg_on_demand_percentage_above_base_capacity = 100`.
 
 ```bash
   terraform init

--- a/faceapi/README.md
+++ b/faceapi/README.md
@@ -48,7 +48,7 @@ Terraform is an Infrastructure as Code (IaC) software tool. With Terraform, you 
 
 > [!IMPORTANT]
 > The default engine is CPU. To deploy a GPU version, do the following:
->   - Set `faceapi_engine` to `gpu` and `faceapi_instance_type` to one of the [`g4dn`](https://aws.amazon.com/ec2/instance-types/g4/) instance types, i.e. `g4dn.large` at the `terraform/main.tf` file.
+>   - Set `faceapi_engine` to `gpu` and `faceapi_instance_type` to one of the [`g4dn`](https://aws.amazon.com/ec2/instance-types/g4/) instance types, i.e. `g4dn.xlarge` at the `terraform/main.tf` file.
 >   - The Packer image also should have `faceapi_engine` set to `gpu`.
 
 ```bash

--- a/faceapi/README.md
+++ b/faceapi/README.md
@@ -25,7 +25,7 @@ Terraform is an Infrastructure as Code (IaC) software tool. With Terraform, you 
 
 - Set a license file to the `packer/artifacts/license/regula.license` folder.
 - Edit the Packer variables file `packer/variables/faceapi.pkrvars.hcl` according to your needs.
-- Required `faceapi_tag` (default "5.2.256.842") can be found at [hub.docker.com](https://hub.docker.com/r/regulaforensics/face-api/tags).
+- Required `faceapi_tag` can be found at [hub.docker.com](https://hub.docker.com/r/regulaforensics/face-api/tags).
 - `faceapi_engine` is either cpu(default) or gpu. This is important for the next Terraform section.
 - Run a Packer build to create AWS AMI.
 
@@ -50,6 +50,9 @@ Terraform is an Infrastructure as Code (IaC) software tool. With Terraform, you 
 > The default engine is CPU. To deploy a GPU version, do the following:
 >   - Set `faceapi_engine` to `gpu` and `faceapi_instance_type` to one of the [`g4dn`](https://aws.amazon.com/ec2/instance-types/g4/) instance types, i.e. `g4dn.xlarge` at the `terraform/main.tf` file.
 >   - The Packer image also should have `faceapi_engine` set to `gpu`.
+
+> [!NOTE]
+> Default AWS quota quota name doesn't allow to run G spot instances, please ensure you've approved request quota limit (L-3819A6DF) before you launch terraform or set instance type to on-demand by following.
 
 ```bash
   terraform init

--- a/faceapi/terraform/modules/app/provider.tf
+++ b/faceapi/terraform/modules/app/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = local.region
+}

--- a/faceapi/terraform/modules/app/variables.tf
+++ b/faceapi/terraform/modules/app/variables.tf
@@ -42,7 +42,7 @@ variable "db_instance_class" {
 variable "db_name" {
   description = "RDS name to deploy"
   type        = string
-  default     = "docreader"
+  default     = "faceapi"
 }
 
 variable "db_username" {

--- a/faceapi/terraform/variables.tf
+++ b/faceapi/terraform/variables.tf
@@ -43,7 +43,7 @@ variable "db_instance_class" {
 variable "db_name" {
   description = "RDS name to deploy"
   type        = string
-  default     = "docreader"
+  default     = "faceapi"
 }
 
 variable "db_username" {


### PR DESCRIPTION
- Docreader/FaceAPI. Add `providers.tf` to fix `eu-central-1` region lock.
- Docreader. Rename default database name
- FaceAPI. Update README.md. Change recommended instance type for gpu to `g4dn.xlarge` 
- FaceAPI. Update README.md. Note about AWS SPOT instance limit increase.
- FaceAPI. Update README.md. Remove default tag