### PR TITLE
fix(renovate): minimumReleaseAge must be a string, not false

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
       "matchManagers": ["github-actions"],
       "matchDepTypes": ["action"],
       "matchPackageNames": ["!regulaforensics/reusable-workflows"],
-      "minimumReleaseAge": false,
+      "minimumReleaseAge": null,
       "pinDigests": true
     }
   ]


### PR DESCRIPTION
## Summary
`renovate.json` had `"minimumReleaseAge": false` in one or more package rules. This is not a valid type for that option — Renovate requires a string (e.g. `"3 days"`) or `null`. As a result Renovate reported `Repository has invalid config` and stopped running entirely for this repo.

## Fix
Changed `"minimumReleaseAge": false` → `"minimumReleaseAge": null`, which is the documented way to disable the minimum release age check for a package rule (per [Renovate docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/#how-do-i-opt-out-dependencies-from-minimum-release-age-checks)).

## Testing
Validated the resulting `renovate.json` is syntactically valid JSON and follows the documented option type.

Ref: https://redmine.regulaforensics.com/issues/63502